### PR TITLE
Build 2.7.12 instead of 2.7.11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 ROOTDIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
 parse_python_version = $(shell echo $@ | sed "s/[^-]*-python-\(.*\)/\1/")
-ALL_PYTHON_VERSIONS = pypy-2.4.0 2.6.9 2.7.11 3.3.6 3.4.4 3.5.1
+ALL_PYTHON_VERSIONS = pypy-2.4.0 2.6.9 2.7.12 3.3.6 3.4.4 3.5.1
 
 all: build push
 
-push: push-python-pypy-2.4.0 push-python-2.7.11 push-python-3.5.1 push-python-all
+push: push-python-pypy-2.4.0 push-python-2.7.12 push-python-3.5.1 push-python-all
 
-build: build-python-pypy-2.4.0 build-python-2.7.11 build-python-3.5.1 build-python-all
+build: build-python-pypy-2.4.0 build-python-2.7.12 build-python-3.5.1 build-python-all
 
 build-python-all:
 	docker build -t vikingco/python:all --build-arg PYTHON_VERSIONS="$(ALL_PYTHON_VERSIONS)" .


### PR DESCRIPTION
2.7.12 is currently the latest stable version of Python 2.7.

This change should ensure that the vikingco/python:2.7.12 image gets built by the CI. vikingco/python:2.7.11 will not receive new builds, but we won't remove any existing images by that tag.